### PR TITLE
'tree' command created

### DIFF
--- a/pysh.py
+++ b/pysh.py
@@ -736,6 +736,54 @@ class Pysh(cmd.Cmd):
                     except PermissionError:
                         print("Internal Error")
 
+    def do_tree(self, *gen_args):
+        gen_args = gen_args[0].split()
+        INVALID_SYNTAX = "pysh: tree: Incorrect Usage: try 'tree' or 'tree [DIRECTORY_PATH]...'"
+
+        if  len(gen_args) > 1:  # found multiple directories
+            for dir_path in gen_args:
+                self.do_tree(dir_path)
+            return
+        elif len(gen_args) == 1: # single directory path found
+            dir_path = gen_args[0]
+        else: # current directory tree call
+            dir_path = '.'
+
+        # if path is not dir or dir does not have read permission
+        if not os.path.isdir(dir_path) or not os.access(dir_path, os.R_OK):
+            print(f"{dir_path} [error opening dir]")
+            print("\n0 (sub)directories, 0 files\n")
+            return
+
+        def helper(indentCount): # recursive helper function
+            fileCount, dirCount = 0, 0
+            content = [ file for file in os.listdir('.') if file[0] != '.' ] # avoiding '.', '..', and hidden files/folders
+
+            for path in content: 
+                if os.path.isdir(path): # if path is directory, then recursively print that directory's tree
+                    dirCount += 1
+                    if os.access(path, os.R_OK): # directory has read permission ?
+                        print(indentCount * '|    ' + '|' + '----' + path)
+                        os.chdir(path)
+                        fCount, dCount = helper(indentCount + 1)
+                        fileCount += fCount
+                        dirCount += dCount
+                        os.chdir('..')
+                    else:
+                        print(indentCount * '|    ' + '|' + '----' + path, '[error opening dir]')
+                else:
+                    fileCount += 1
+                    print(indentCount * '|    ' + '|' + '----' + path)
+
+            return dirCount, fileCount
+        
+        cwd = os.getcwd()
+        os.chdir(dir_path)
+        print(dir_path)
+        dir_count, file_count = helper(0)
+        os.chdir(cwd)
+        print(f"\n{dir_count} (sub)directories, {file_count} files\n")
+
     # help section
 
     def help_exit(self):
@@ -830,6 +878,9 @@ class Pysh(cmd.Cmd):
 
     def help_chmod(self):
         print(commands_list_manual['chmod'])
+
+    def help_tree(self):
+        print(commands_list_manual['tree'])
 
     def default(self, line: str) -> bool:
         self.stdout.write("pysh: command not found: {}\n".format(line))

--- a/utils/commands_list.py
+++ b/utils/commands_list.py
@@ -1,7 +1,7 @@
 commands_list = ['lf', 'ldir', 'pwd', 'cd', 'manual', 'mkdir',
                  'calendar', 'calc', 'whoami', 'echo', 'rm',
                  'cat', 'cp', 'mv', 'date', 'file', 'history',
-                 'head', 'tail', 'touch', 'wc', 'ip', 'host', 'arch', 'ps', 'wget', 'kill', 'diff', 'chmod', 'grep']
+                 'head', 'tail', 'touch', 'wc', 'ip', 'host', 'arch', 'ps', 'wget', 'kill', 'diff', 'chmod', 'grep', 'tree']
 
 commands_list_manual = {
     'exit': "Exits the shell where it is currently running. \nusage: 'exit'",
@@ -36,5 +36,6 @@ commands_list_manual = {
     'kill': "Terminate an unresponsive program. \nusage: 'kill [PID]'",
     'diff': "Compares files line by line. \nusage: 'diff [FILE1] [FILE2]'",
     'grep': "Utility for searching plain-text data sets for lines that match a regular expression. \nusage: 'grep [expression] [data-set] -f' {if the data-set is a file}\nusage: 'grep [expression] [data-set]' {if the data-set is an input string}",
-    'chmod': "Changes access permissions and the special mode flags of file system objects. \nusage: 'chmod [PERMISSIONS] [FILES]...'"
+    'chmod': "Changes access permissions and the special mode flags of file system objects. \nusage: 'chmod [PERMISSIONS] [FILES]...'",
+    'tree': "Lists content of directories in tree like format. The current directory is listed by default if no directory path is provided. \nusage: 'tree' OR 'tree [DIRECTORY_PATH]'",
 }


### PR DESCRIPTION
Added tree command, its help call, and manual info. The command print the contents of the directory path in a tree like format. If no arguement is provided, then current directory is taken, else the list of paths provided as input are iteratively taken to print the tree.